### PR TITLE
#6: NullReferenceException in Bugsnag.NET.Request.StackTraceLine.<Build>d__1.MoveNext()

### DIFF
--- a/Bugsnag.NET.Tests/Request/NoticeTests.cs
+++ b/Bugsnag.NET.Tests/Request/NoticeTests.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Bugsnag.NET.Request;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;
 using NUnit.Framework;
@@ -22,6 +23,17 @@ namespace Bugsnag.NET.Tests.Request
             var jObject = JObject.Parse(json);
 
             Assert.IsTrue(jObject.IsValid(schema));
+        }
+
+        [Test]
+        public void StackIsAbsent()
+        {
+            const string InternalErrorMessage = "An internal error has occurred!";
+            Exception ex = new Exception(InternalErrorMessage, new Exception("Debug Info: " + Environment.NewLine + "Some debug information goes here..."));
+            var ev = new Event(ex);
+            var notice = new Notice("apikey", new Notifier(), ev);
+            var json = JsonConvert.SerializeObject(notice);
+            // should reach the end of function without any exception thrown
         }
 
         JsonSchema _GetSchema()

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -25,7 +25,7 @@ namespace Bugsnag.NET.Extensions
 
         public static IEnumerable<string> ToLines(this Exception ex)
         {
-            if (ex == null) { return Enumerable.Empty<string>(); }
+            if (ex == null || ex.StackTrace == null) { return Enumerable.Empty<string>(); }
 
             return ex.StackTrace.Split(
                 new string[] { Environment.NewLine },

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -45,7 +45,8 @@ namespace Bugsnag.NET.Extensions
 
         public static string ParseMethodName(this string line)
         {
-            var match = Regex.Match(line, "at .+\\.([^\\.]+\\(.*\\))");
+            // to extract the full method name (with namespace)
+            var match = Regex.Match(line, "at ([^)]+[)])");
             if (match.Groups.Count < 2) { return "[method]"; }
 
             return match.Groups[1].Value;

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -25,7 +25,10 @@ namespace Bugsnag.NET.Extensions
 
         public static IEnumerable<string> ToLines(this Exception ex)
         {
-            if (ex == null || ex.StackTrace == null) { return Enumerable.Empty<string>(); }
+            if (ex == null || ex.StackTrace == null)
+            {
+                return new string[] { String.Empty };
+            }
 
             return ex.StackTrace.Split(
                 new string[] { Environment.NewLine },

--- a/Bugsnag.NET/Properties/AssemblyInfo.cs
+++ b/Bugsnag.NET/Properties/AssemblyInfo.cs
@@ -28,6 +28,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.0.0")]
-[assembly: AssemblyFileVersion("0.2.0.0")]
-[assembly: AssemblyInformationalVersion("0.2.0")]
+[assembly: AssemblyVersion("0.3.0.0")]
+[assembly: AssemblyFileVersion("0.3.0.0")]
+[assembly: AssemblyInformationalVersion("0.3.0")]

--- a/Bugsnag.NET/Request/Event.cs
+++ b/Bugsnag.NET/Request/Event.cs
@@ -93,10 +93,12 @@ namespace Bugsnag.NET.Request
         static string _GetContext(Exception ex)
         {
             if (ex == null) { return string.Empty; }
+            var targetSite = ex.TargetSite;
 
-            return string.Format("{0}::{1}",
-                ex.TargetSite.DeclaringType,
-                ex.TargetSite.Name);
+            return targetSite == null ? "NullTargetSite" :
+                string.Format("{0}::{1}",
+                targetSite.DeclaringType,
+                targetSite.Name);
         }
 
         static string _GetContext(IEnumerable<Exception> unwrapped)

--- a/Bugsnag.NET/Request/Event.cs
+++ b/Bugsnag.NET/Request/Event.cs
@@ -95,7 +95,7 @@ namespace Bugsnag.NET.Request
             if (ex == null) { return string.Empty; }
             var targetSite = ex.TargetSite;
 
-            return targetSite == null ? "NullTargetSite" :
+            return targetSite == null ? "null::null" :
                 string.Format("{0}::{1}",
                 targetSite.DeclaringType,
                 targetSite.Name);


### PR DESCRIPTION
Fixed cases when either Stack or TargetSite is null in the Exception object