### PR TITLE
Add dummy stacktrace when missing from exception

### DIFF
--- a/Bugsnag.PCL/Extensions/Extensions.cs
+++ b/Bugsnag.PCL/Extensions/Extensions.cs
@@ -26,7 +26,7 @@ namespace Bugsnag.PCL.Extensions
         {
             if (ex == null || ex.StackTrace == null)
             {
-                return Enumerable.Empty<string>();
+                return new string[] { String.Empty };
             }
 
             return ex.StackTrace.Split(


### PR DESCRIPTION
This is intended as a temporary workaround for https://github.com/awseward/Bugsnag.NET/issues/23 while a better long term solution gets underway.

Instead of giving an empty IEnumerable, giving an array with a single empty string allows Bugsnag's API to receive notifications for exceptions containing an empty or missing stack trace.

Thanks to @mliyanagamage for tracking down the cause of the issue down.