### PR TITLE
Add stacktrace to event if missing

### DIFF
--- a/Bugsnag.PCL/Request/Error.cs
+++ b/Bugsnag.PCL/Request/Error.cs
@@ -16,6 +16,6 @@ namespace Bugsnag.PCL.Request
 
         public string Message { get; private set; }
 
-        public IEnumerable<IStackTraceLine> Stacktrace { get; private set; }
+        public IEnumerable<IStackTraceLine> Stacktrace { get; set; }
     }
 }

--- a/Bugsnag.PCL/Request/Event.cs
+++ b/Bugsnag.PCL/Request/Event.cs
@@ -111,5 +111,15 @@ namespace Bugsnag.PCL.Request
         {
             return _unknownMethod;
         }
+
+        public void AddContext(string memberName, string sourceFilePath, int sourceLineNumber)
+        {
+            Context = memberName;
+            
+            foreach (var error in Errors.Where(error => !error.Stacktrace.Any()))
+            {
+                error.Stacktrace = StackTraceLine.BuildWithContext(memberName, sourceFilePath, sourceLineNumber);
+            }
+        }
     }
 }

--- a/Bugsnag.PCL/Request/Interfaces/IError.cs
+++ b/Bugsnag.PCL/Request/Interfaces/IError.cs
@@ -13,6 +13,6 @@ namespace Bugsnag.PCL.Request
         string Message { get; }
 
         [JsonProperty("stacktrace")]
-        IEnumerable<IStackTraceLine> Stacktrace { get; }
+        IEnumerable<IStackTraceLine> Stacktrace { get; set; }
     }
 }

--- a/Bugsnag.PCL/Request/Interfaces/IEvent.cs
+++ b/Bugsnag.PCL/Request/Interfaces/IEvent.cs
@@ -32,5 +32,7 @@ namespace Bugsnag.PCL.Request
 
         [JsonProperty("metaData")]
         object MetaData { get; }
+
+        void AddContext(string memberName, string sourceFilePath, int sourceLineNumber);
     }
 }

--- a/Bugsnag.PCL/Request/StackTraceLine.cs
+++ b/Bugsnag.PCL/Request/StackTraceLine.cs
@@ -19,6 +19,16 @@ namespace Bugsnag.PCL.Request
             }
         }
 
+        internal static IEnumerable<IStackTraceLine> BuildWithContext(string memberName, string sourceFilePath, int sourceLineNumber)
+        {
+            yield return new StackTraceLine
+            {
+                File = sourceFilePath,
+                LineNumber = sourceLineNumber,
+                Method = memberName
+            };
+        }
+
         public string File { get; private set; }
 
         public int LineNumber { get; private set; }


### PR DESCRIPTION
This commit adds a method to IEvent, `AddContext` which allows the developer to add a method name, source file path and a source line number. This is best used in conjunction with [caller information](https://msdn.microsoft.com/en-us/library/hh534540.aspx). 

This has not been added to the .NET part of the library yet, only the PCL. This pull request is mostly for feedback before reflecting the changes on both parts.