### PR TITLE
Add IBugsnagger-based interface

### DIFF
--- a/Bugsnag.NET.Tests/IntegrationTests.cs
+++ b/Bugsnag.NET.Tests/IntegrationTests.cs
@@ -3,23 +3,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Bugsnag.NET.Extensions;
 using NUnit.Framework;
 using BsNET = Bugsnag.NET;
 using BsReq = Bugsnag.NET.Request;
 
 namespace Bugsnag.NET.Tests
 {
+    [Ignore]
     public class IntegrationTests
     {
         [Test]
-        [Ignore]
         public void SendAnError_StaticApproach()
         {
             StaticApproachApplication.Main();
         }
 
         [Test]
-        [Ignore]
         public void SendAnError_InstanceApproach()
         {
             InstanceApproachApplication.Main();
@@ -54,10 +54,10 @@ namespace Bugsnag.NET.Tests
 
         static void _OnUnhandledException(Exception ex)
         {
-            // FIXME: Event creation is still a little funky...
-            var @event = BsNET.Bugsnag.Error.GetEvent(ex, null, null);
+            var snagger = _Bugsnagger;
+            var @event = snagger.CreateEvent(BsReq.Severity.Error, ex, null, null);
 
-            _Bugsnagger.Notify(@event);
+            snagger.Notify(@event);
         }
     }
 

--- a/Bugsnag.NET/Bugsnag.cs
+++ b/Bugsnag.NET/Bugsnag.cs
@@ -77,7 +77,7 @@ namespace Bugsnag.NET
         private Bugsnag(Severity severity)
         {
             _severity = severity;
-            _snagger = new Bugsnagger
+            Snagger = new Bugsnagger
             {
                 ApiKey = ApiKey,
                 Notifier = Notifier,
@@ -88,12 +88,12 @@ namespace Bugsnag.NET
 
         readonly Severity _severity;
 
-        readonly IBugsnagger _snagger;
+        public IBugsnagger Snagger { get; }
 
-        public void Notify(IEvent evt) => _snagger.Notify(evt);
-        public void Notify(IEvent evt, bool useSSL) => _snagger.Notify(evt, useSSL);
-        public void Notify(IEnumerable<IEvent> events) => _snagger.Notify(events);
-        public void Notify(IEnumerable<IEvent> events, bool useSSL) => _snagger.Notify(events, useSSL);
+        public void Notify(IEvent evt) => Snagger.Notify(evt);
+        public void Notify(IEvent evt, bool useSSL) => Snagger.Notify(evt, useSSL);
+        public void Notify(IEnumerable<IEvent> events) => Snagger.Notify(events);
+        public void Notify(IEnumerable<IEvent> events, bool useSSL) => Snagger.Notify(events, useSSL);
 
         public IEvent GetEvent(Exception ex, IUser user, object metaData)
         {

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -3,11 +3,46 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Bugsnag.NET.Request;
 
 namespace Bugsnag.NET.Extensions
 {
     static class Extensions
     {
+        public static IEvent CreateEvent(
+            this IBugsnagger snagger,
+            Severity severity,
+            Exception ex,
+            IUser user,
+            object metadata)
+        {
+            return new Event(ex)
+            {
+                App = snagger.App,
+                Device = snagger.Device,
+                User = user,
+                Severity = severity.ToString(),
+                MetaData = metadata,
+            };
+        }
+
+        public static IEvent CreateEvent(
+            this IBugsnagger snagger,
+            Severity severity,
+            IEnumerable<Exception> unwrapped,
+            IUser user,
+            object metadata)
+        {
+            return new Event(unwrapped)
+            {
+                App = snagger.App,
+                Device = snagger.Device,
+                User = user,
+                Severity = severity.ToString(),
+                MetaData = metadata,
+            };
+        }
+
         /// <remarks>Not sure I'm really thrilled with this...</remarks>
         public static IEnumerable<Exception> Unwrap(this Exception ex)
         {

--- a/Bugsnag.NET/Request/Severity.cs
+++ b/Bugsnag.NET/Request/Severity.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Bugsnag.NET.Request
 {
-    abstract class Severity
+    public abstract class Severity
     {
         private Severity() { }
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,218 @@ Install-Package Bugsnag.PCL
 ```
 
 ## Usage
-A simple example of how one might use this client.
+Some simple examples of how to use this client.
+
+### Configuration
+#### Use the default `IBugsnagger` instance
+This library provides a default `IBugsnagger` instance you can set some properties on to set up your integration.
+
+Your setup might look something like this.
+```cs
+using System;
+// ...
+using Bugsnag.NET;
+using Bugsnag.NET.Extensions;
+using BsReq = Bugsnag.NET.Request;
+
+// ...
+
+    static void _InitBugsnag()
+    {
+        var snagger = Bugsnagger.Default;
+
+        snagger.ApiKey = "YOUR_API_KEY_HERE";
+        snagger.App = new BsReq.App
+        {
+            Version = "1.2.3",
+            ReleaseStage = "test",
+        };
+    }
+
+// ...
+```
+
+#### Bring your own `IBugsnagger`
+Alternatively, you can choose to create your own `IBugsnagger` instance (or multiple), and hold references to it/them somewhere.
+
+That might look something like this.
+```cs
+using System;
+// ...
+using Bugsnag.NET;
+using Bugsnag.NET.Extensions;
+using BsReq = Bugsnag.NET.Request;
+
+// ...
+
+    static IBugsnagger _Snagger { get; } = new Bugsnagger
+    {
+        ApiKey = "YOUR_API_KEY_HERE",
+        App = new BsReq.App
+        {
+            Version = "1.2.3",
+            ReleaseStage = "test",
+        },
+    };
+
+// ...
+```
+
+### Capture Errors
+Depending on which approach you choose to take in your application, a simple setup to start sending application errors to Bugsnag might look like one of the following.
+
+#### Default `IBugsnagger` instance
+```cs
+using System;
+// ...
+using Bugsnag.NET;
+using Bugsnag.NET.Extensions;
+using BsReq = Bugsnag.NET.Request;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        _InitBugsnag();
+
+        try
+        {
+            // Your app code here
+        }
+        catch (Exception ex)
+        {
+            _NotifyBugsnag(ex);
+
+            throw;
+        }
+    }
+
+    static void _InitBugsnag()
+    {
+        var snagger = Bugsnagger.Default;
+
+        snagger.ApiKey = "YOUR_API_KEY_HERE";
+        snagger.App = new BsReq.App
+        {
+            Version = "1.2.3",
+            ReleaseStage = "test",
+        };
+    }
+
+    static void _NotifyBugsnag(Exception ex)
+    {
+        var snagger = Bugsnagger.Default;
+        var snagEvent = snagger.CreateEvent(
+            BsReq.Severity.Error,
+            ex,
+            _GetUser(),
+            _GetMetadata());
+
+        snagger.Notify(snagEvent);
+    }
+
+    static BsReq.IUser _GetUser() { /* ... */ }
+
+    static object _GetMetadata() { /* See Metadata section */ }
+}
+```
+
+#### Custom `IBugsnagger` instance
+```cs
+using System;
+// ...
+using Bugsnag.NET;
+using Bugsnag.NET.Extensions;
+using BsReq = Bugsnag.NET.Request;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        try
+        {
+            // Your app code here
+        }
+        catch (Exception ex)
+        {
+            var snagEvent = _Snagger.CreateEvent(BsReq.Severity.Error, ex, null, null);
+            _Snagger.Notify(snagEvent);
+
+            throw;
+        }
+    }
+
+    static IBugsnagger _Snagger { get; } = new Bugsnagger
+    {
+        ApiKey = "YOUR_API_KEY_HERE",
+        App = new BsReq.App
+        {
+            Version = "1.2.3",
+            ReleaseStage = "test"
+        },
+    };
+
+    static void _NotifyBugsnag(Exception ex)
+    {
+        var snagEvent = _Snagger.CreateEvent(
+            BsReq.Severity.Error,
+            ex,
+            _GetUser(),
+            _GetMetadata());
+
+        _Snagger.Notify(snagEvent);
+    }
+
+    static BsReq.IUser _GetUser() { /* ... */ }
+
+    static object _GetMetadata() { /* See Metadata section */ }
+}
+```
+
+### Metadata
+Metadata can be passed in as anonymous types, as Bugsnag expects key/value
+pairs for these.
+
+For example, the following will create two extra tabs in Bugnsag's online
+interface which will have the labels "firstTab" and "secondTab", respectively:
+```cs
+object GetMetadata() {
+{
+    return new
+    {
+        firstTab = new
+        {
+            someKey = "some value",
+        },
+        secondTab = new
+        {
+            anotherKey = "another value",
+        },
+    };
+}
+```
+
+For keys/values at the root level of this metadata object, Bugsnag creates a tab
+for you with the label "Custom", and displays them there. That case would look
+like this:
+```cs
+object GetMetadata() {
+    return new
+    {
+        keyUnderCustomTab = "some value",
+        anotherKeyUnderCustomTab = "another value",
+    }
+}
+```
+
+---
+
+### Statically Configured Approach
+This was the initial implementation of this tool's interface.
+
+It consists solely of static properties, which makes it slightly less flexible. Because of this, its use is discouraged and is being considered for deprecation.
 ```csharp
+//
 using BsNET = Bugsnag.NET;
 using BsReq = Bugsnag.NET.Request;
 
@@ -57,41 +267,5 @@ using BsReq = Bugsnag.NET.Request;
 
   BsReq.IUser GetCurrentUser() { ... }
 
-  object GetMetadata() { /* See Metadata section below */ }
-```
-
-### Metadata
-Metadata can be passed in as anonymous types, as Bugsnag expects key/value
-pairs for these.
-
-For example, the following will create two extra tabs in Bugnsag's online
-interface which will have the labels "firstTab" and "secondTab", respectively:
-```cs
-object GetMetadata() {
-{
-    return new
-    {
-        firstTab = new
-        {
-            someKey = "some value",
-        },
-        secondTab = new
-        {
-            anotherKey = "another value",
-        },
-    };
-}
-```
-
-For keys/values at the root level of this metadata object, Bugsnag creates a tab
-for you with the label "Custom", and displays them there. That case would look
-like this:
-```cs
-object GetMetadata() {
-    return new
-    {
-        keyUnderCustomTab = "some value",
-        anotherKeyUnderCustomTab = "another value",
-    }
-}
+  object GetMetadata() { /* See Metadata section */ }
 ```


### PR DESCRIPTION
This allows a consumer to snag bugs via a slightly more flexible, `IBugsnagger` interface.

`Bugsnagger`, the default implementation of `IBugsnagger`, can be instantiated, or the consumer can use the provided static instance `Bugsnagger.Default`.

Further information about this has been added to the readme.

Consumers using the preexisting, `Bugsnag` (which could only be configured via static properties) class should be unaffected. I'm considering deprecating this class in the near future, however.

#### [Pre-release nupkg available here](https://www.nuget.org/packages/Bugsnag.NET/0.6.0-pre)