### PR TITLE
Remove message from default grouping hash

### DIFF
--- a/Bugsnag.NET/Request/Event.cs
+++ b/Bugsnag.NET/Request/Event.cs
@@ -71,10 +71,10 @@ namespace Bugsnag.NET.Request
             if (ex == null) { return string.Empty; }
 
             return string.Format(
-                "{0} @ {1} : {2}",
+                "{0}@{1}",
                 _GetTypeName(ex),
-                _GetContext(ex),
-                _GetMessage(ex));
+                _GetContext(ex)
+            );
         }
 
         static string _GetMessage(Exception ex)

--- a/Bugsnag.PCL/Request/Event.cs
+++ b/Bugsnag.PCL/Request/Event.cs
@@ -69,9 +69,10 @@ namespace Bugsnag.PCL.Request
             if (ex == null) { return string.Empty; }
 
             return string.Format(
-                "{0} @ {1}",
+                "{0}@{1}",
                 _GetTypeName(ex),
-                _GetMessage(ex));
+                _GetMessage(ex)
+            );
         }
 
         static string _GetMessage(Exception ex)


### PR DESCRIPTION
This only affects the non-PCL side of things.

The PCL was already not including the message.