### PR TITLE
Preserve async/await stacktraces

### DIFF
--- a/Bugsnag.NET.Tests/Bugsnag.NET.Tests.csproj
+++ b/Bugsnag.NET.Tests/Bugsnag.NET.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="StacktracelineParsingTests.cs" />
     <Compile Include="ExceptionExtensionTests.cs" />
     <Compile Include="Integration\IntegrationTests.PCL.cs" />
     <Compile Include="Integration\Utils\InstanceApproachApp.cs" />

--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Bugsnag.Common.Extensions;
 using NUnit.Framework;
 
 namespace Bugsnag.NET.Tests
@@ -26,12 +27,18 @@ namespace Bugsnag.NET.Tests
         readonly string _frameworkLine = @"   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)";
         readonly string _asyncAwaitPreviousLocationLine = @"--- End of stack trace from previous location where exception was thrown ---";
 
+        readonly string _parseFailedMethodName = "[method]";
+        readonly string _parseFailedFile = "[file]";
+        readonly int _parseFailedLineNumber = -1;
+
         [Test]
         public void CanParseSourceLineWithFileInfo()
         {
             var line = _sourceLine;
 
-            Assert.Fail();
+            Assert.AreNotEqual(_parseFailedMethodName, line.ParseMethodName());
+            Assert.AreNotEqual(_parseFailedFile, line.ParseFile());
+            Assert.AreNotEqual(_parseFailedLineNumber, line.ParseLineNumber());
         }
 
         [Test]

--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -46,7 +46,9 @@ namespace Bugsnag.NET.Tests
         {
             var line = _frameworkLine;
 
-            Assert.Fail();
+            Assert.AreNotEqual(_parseFailedMethodName, line.ParseMethodName());
+            Assert.AreEqual(_parseFailedFile, line.ParseFile());
+            Assert.AreEqual(_parseFailedLineNumber, line.ParseLineNumber());
         }
 
         [Test]

--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Bugsnag.NET.Tests
+{
+    public class StacktracelineParsingTests
+    {
+        // NOTE: Cases here based on this random stacktrace I grabbed off of StackOverflow:
+        // at NLogAsyncExceptionTestCase.Program.<Bar>d__d.MoveNext() in c:\Users\ComputerUser\Documents\Visual Studio 2012\Projects\NLogAsyncExceptionTestCase\NLogAsyncExceptionTestCase.Console\Program.cs:line 53
+        // --- End of stack trace from previous location where exception was thrown ---
+        //    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
+        //    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
+        //    at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
+        //    at NLogAsyncExceptionTestCase.Program.<Foo>d__8.MoveNext() in c:\Users\ComputerUser\Documents\Visual Studio 2012\Projects\NLogAsyncExceptionTestCase\NLogAsyncExceptionTestCase.Console\Program.cs:line 44
+        // --- End of stack trace from previous location where exception was thrown ---
+        //    at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
+        //    at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
+        //    at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
+        //    at NLogAsyncExceptionTestCase.Program.<CheckFooAndBar>d__0.MoveNext() in c:\Users\ComputerUser\Documents\Visual Studio 2012\Projects\NLogAsyncExceptionTestCase\NLogAsyncExceptionTestCase.Console\Program.cs:line 30
+
+        readonly string _sourceLine = @"at NLogAsyncExceptionTestCase.Program.<Bar>d__d.MoveNext() in c:\Users\ComputerUser\Documents\Visual Studio 2012\Projects\NLogAsyncExceptionTestCase\NLogAsyncExceptionTestCase.Console\Program.cs:line 53";
+        readonly string _frameworkLine = @"   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)";
+        readonly string _asyncAwaitPreviousLocationLine = @"--- End of stack trace from previous location where exception was thrown ---";
+
+        [Test]
+        public void CanParseSourceLineWithFileInfo()
+        {
+            var line = _sourceLine;
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void CanParseFrameworkLineLackingFileInfo()
+        {
+            var line = _frameworkLine;
+
+            Assert.Fail();
+        }
+
+        [Test]
+        public void CanParseAsyncAwaitPreviousLocationLine()
+        {
+            var line = _asyncAwaitPreviousLocationLine;
+
+            Assert.Fail();
+        }
+    }
+}

--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -56,7 +56,9 @@ namespace Bugsnag.NET.Tests
         {
             var line = _asyncAwaitPreviousLocationLine;
 
-            Assert.Fail();
+            Assert.AreEqual(_asyncAwaitPreviousLocationLine, line.ParseMethodName());
+            Assert.AreEqual(_parseFailedFile, line.ParseFile());
+            Assert.AreEqual(_parseFailedLineNumber, line.ParseLineNumber());
         }
     }
 }

--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -56,7 +56,13 @@ namespace Bugsnag.NET.Tests
         {
             var line = _asyncAwaitPreviousLocationLine;
 
+            // NOTE: This one stands out a bit. If we fail to parse the method name,
+            // which we're considering the "bare minimum", we just return the whole
+            // line as the method name. It feels a bit driven by the way Bugsnag
+            // expects payloads, but this is a Bugsnag lib, so this probably doesn't
+            // matter all that much...
             Assert.AreEqual(_asyncAwaitPreviousLocationLine, line.ParseMethodName());
+
             Assert.AreEqual(_parseFailedFile, line.ParseFile());
             Assert.AreEqual(_parseFailedLineNumber, line.ParseLineNumber());
         }

--- a/lib/Bugsnag.Common/Extensions/CommonExtensions.cs
+++ b/lib/Bugsnag.Common/Extensions/CommonExtensions.cs
@@ -48,7 +48,7 @@ namespace Bugsnag.Common.Extensions
         {
             // to extract the full method name (with namespace)
             var match = Regex.Match(line, "at ([^)]+[)])");
-            if (match.Groups.Count < 2) { return "[method]"; }
+            if (match.Groups.Count < 2) { return line; }
 
             return match.Groups[1].Value;
         }


### PR DESCRIPTION
### Issue this Addresses: https://github.com/awseward/Bugsnag.NET/issues/47

Original issue text at the time of this PR:
>Parse lines in awaited stack traces to indicate where this occurs.
>```
>--- End of stack trace from previous location where exception was thrown ---
>```
>
>Currently showing this, which could be improved.
>```
>[file]:-1 [method]
>```

### What should now show in Bugsnag

```
[file]:-1 --- End of stack trace from previous location where exception was thrown ---
```

### Prerelease packages available to try this out

https://www.nuget.org/packages/Bugsnag.NET/0.8.1-andouille
https://www.nuget.org/packages/Bugsnag.PCL/0.8.1-andouille