### PR TITLE
Fix AssemblyInfoFilePaths in FAKE config

### DIFF
--- a/._fake/config.fsx
+++ b/._fake/config.fsx
@@ -14,7 +14,7 @@ module Build =
   let TestAssemblies = !! "Bugsnag.NET.Tests/**/*.Tests.dll" -- "**/obj/**/*.Tests.dll"
   let DotNetVersion = "4.5"
   let MSBuildArtifacts = !! "**/bin/**.*" ++ "**/obj/**/*.*"
-  let AssemblyInfoFilePaths = !! "SharedAssemblyInfo.cs"
+  let AssemblyInfoFilePaths = ["SharedAssemblyInfo.cs"]
 
 module Nuget =
   let ApiEnvVar      = "BUGSNAG_NET_NUGET_API_KEY"


### PR DESCRIPTION
Needs to just be a list, not the FAKE FileIncludes, to work.