### PR TITLE
Don't ignore null values when serializing

### DIFF
--- a/Bugsnag.NET.Tests/Integration/IntegrationTests.NET.cs
+++ b/Bugsnag.NET.Tests/Integration/IntegrationTests.NET.cs
@@ -108,17 +108,24 @@ namespace Bugsnag.Tests.Integration
             static void _OnUnhandledException(Exception ex)
             {
                 var client = BsNET.Bugsnag.Error;
-                var @event = client.GetEvent(ex, null, null);
+                var @event = client.GetEvent(ex, null, _GetMetadata());
 
                 client.Notify(@event);
             }
             static Task _OnUnhandledExceptionAsync(Exception ex)
             {
                 var client = BsNET.Bugsnag.Error;
-                var @event = client.GetEvent(ex, null, null);
+                var @event = client.GetEvent(ex, null, _GetMetadata());
 
                 return client.NotifyAsync(@event);
             }
+
+            static object _GetMetadata() =>
+                new
+                {
+                    Foo = "bar",
+                    Baz = (object)null,
+                };
         }
     }
 }

--- a/Bugsnag.NET.Tests/Integration/IntegrationTests.PCL.cs
+++ b/Bugsnag.NET.Tests/Integration/IntegrationTests.PCL.cs
@@ -107,17 +107,24 @@ namespace Bugsnag.Tests.Integration
             static void _OnUnhandledException(Exception ex)
             {
                 var client = BsPCL.Bugsnag.Error;
-                var @event = client.GetEvent(ex, null, null);
+                var @event = client.GetEvent(ex, null, _GetMetadata());
 
                 client.Notify(@event);
             }
             static Task _OnUnhandledExceptionAsync(Exception ex)
             {
                 var client = BsPCL.Bugsnag.Error;
-                var @event = client.GetEvent(ex, null, null);
+                var @event = client.GetEvent(ex, null, _GetMetadata());
 
                 return client.NotifyAsync(@event);
             }
+
+            static object _GetMetadata() =>
+                new
+                {
+                    Foo = "bar",
+                    Baz = (object)null,
+                };
         }
     }
 }

--- a/Bugsnag.NET.Tests/Integration/Utils/Utils.cs
+++ b/Bugsnag.NET.Tests/Integration/Utils/Utils.cs
@@ -81,7 +81,7 @@ namespace Bugsnag.Tests.Integration
 
         public ITestApp TestApp(Func<IBugsnagger, Action<Exception, IUser, object>> getNotify)
         {
-            return TestApp((snagger, ex) => getNotify(snagger)(ex, null, null));
+            return TestApp((snagger, ex) => getNotify(snagger)(ex, null, _GetMetadata()));
         }
 
         public IAsyncTestApp AsyncTestApp(Func<IBugsnagger, Exception, Task> notifyAsync)
@@ -91,7 +91,14 @@ namespace Bugsnag.Tests.Integration
 
         public IAsyncTestApp AsyncTestApp(Func<IBugsnagger, Func<Exception, IUser, object, Task>> getNotify)
         {
-            return AsyncTestApp((snagger, ex) => getNotify(snagger)(ex, null, null));
+            return AsyncTestApp((snagger, ex) => getNotify(snagger)(ex, null, _GetMetadata()));
         }
+
+        object _GetMetadata() =>
+            new
+            {
+                Foo = "bar",
+                Baz = (object) null,
+            };
     }
 }

--- a/lib/Bugsnag.Common/BugsnagClient.cs
+++ b/lib/Bugsnag.Common/BugsnagClient.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Bugsnag.Common
 {
@@ -12,10 +12,7 @@ namespace Bugsnag.Common
     {
         static Uri _uri = new Uri("http://notify.bugsnag.com");
         static Uri _sslUri = new Uri("https://notify.bugsnag.com");
-        static JsonSerializerSettings _settings = new JsonSerializerSettings
-        {
-            NullValueHandling = NullValueHandling.Ignore
-        };
+        static JsonSerializerSettings _settings = new JsonSerializerSettings { };
         static HttpClient _HttpClient { get; } = new HttpClient();
 
         public void Send(INotice notice) => Send(notice, true);


### PR DESCRIPTION
It's a little more helpful to see values show up as a null in a bugsnag event's metadata rather than just not show up at all.