### PR TITLE
Add transformStackTraceLine concept

### DIFF
--- a/Bugsnag.NET/Bugsnag.NET.csproj
+++ b/Bugsnag.NET/Bugsnag.NET.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Request\StackTraceLine.cs" />
     <Compile Include="Request\Thread.cs" />
     <Compile Include="Request\User.cs" />
+    <Compile Include="StackTraceLineHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\lib\Bugsnag.Common\Bugsnag.Common.csproj">

--- a/Bugsnag.NET/Bugsnag.cs
+++ b/Bugsnag.NET/Bugsnag.cs
@@ -50,7 +50,7 @@ namespace Bugsnag.NET
 
         public IEvent GetEvent(Exception ex, IUser user, object metaData)
         {
-            return new Event(ex, Snagger.TransformStacktraceLine)
+            return new Event(ex, Snagger.FinalizeStacktraceLine)
             {
                 App = App,
                 Device = Device,
@@ -62,7 +62,7 @@ namespace Bugsnag.NET
 
         public IEvent GetEvent(IEnumerable<Exception> unwrapped, IUser user, object metaData)
         {
-            return new Event(unwrapped, Snagger.TransformStacktraceLine)
+            return new Event(unwrapped, Snagger.FinalizeStacktraceLine)
             {
                 App = App,
                 Device = Device,

--- a/Bugsnag.NET/Bugsnag.cs
+++ b/Bugsnag.NET/Bugsnag.cs
@@ -50,7 +50,7 @@ namespace Bugsnag.NET
 
         public IEvent GetEvent(Exception ex, IUser user, object metaData)
         {
-            return new Event(ex)
+            return new Event(ex, Snagger.TransformStacktraceLine)
             {
                 App = App,
                 Device = Device,
@@ -62,7 +62,7 @@ namespace Bugsnag.NET
 
         public IEvent GetEvent(IEnumerable<Exception> unwrapped, IUser user, object metaData)
         {
-            return new Event(unwrapped)
+            return new Event(unwrapped, Snagger.TransformStacktraceLine)
             {
                 App = App,
                 Device = Device,

--- a/Bugsnag.NET/Bugsnagger.cs
+++ b/Bugsnag.NET/Bugsnagger.cs
@@ -18,6 +18,7 @@ namespace Bugsnag.NET
         public IApp App { get; set; } = new App();
         public IDevice Device { get; set; } = new Device();
         public INotifier Notifier { get; set; } = new Notifier();
+        public Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; } = x => x;
 
         [Obsolete("Has not been verified to work yet")]
         public Task<HttpResponseMessage> ErrorAsync(Exception ex, IUser user, object metadata)

--- a/Bugsnag.NET/Bugsnagger.cs
+++ b/Bugsnag.NET/Bugsnagger.cs
@@ -18,7 +18,7 @@ namespace Bugsnag.NET
         public IApp App { get; set; } = new App();
         public IDevice Device { get; set; } = new Device();
         public INotifier Notifier { get; set; } = new Notifier();
-        public Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; } = x => x;
+        public Func<IMutableStackTraceLine, IStackTraceLine> FinalizeStacktraceLine { get; set; } = x => x;
 
         [Obsolete("Has not been verified to work yet")]
         public Task<HttpResponseMessage> ErrorAsync(Exception ex, IUser user, object metadata)

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -17,7 +17,7 @@ namespace Bugsnag.NET
             IUser user,
             object metadata)
         {
-            return new Event(ex)
+            return new Event(ex, snagger.TransformStacktraceLine)
             {
                 App = snagger.App,
                 Device = snagger.Device,
@@ -34,7 +34,7 @@ namespace Bugsnag.NET
             IUser user,
             object metadata)
         {
-            return new Event(unwrapped)
+            return new Event(unwrapped, snagger.TransformStacktraceLine)
             {
                 App = snagger.App,
                 Device = snagger.Device,

--- a/Bugsnag.NET/Extensions/Extensions.cs
+++ b/Bugsnag.NET/Extensions/Extensions.cs
@@ -17,7 +17,7 @@ namespace Bugsnag.NET
             IUser user,
             object metadata)
         {
-            return new Event(ex, snagger.TransformStacktraceLine)
+            return new Event(ex, snagger.FinalizeStacktraceLine)
             {
                 App = snagger.App,
                 Device = snagger.Device,
@@ -34,7 +34,7 @@ namespace Bugsnag.NET
             IUser user,
             object metadata)
         {
-            return new Event(unwrapped, snagger.TransformStacktraceLine)
+            return new Event(unwrapped, snagger.FinalizeStacktraceLine)
             {
                 App = snagger.App,
                 Device = snagger.Device,

--- a/Bugsnag.NET/Request/Error.cs
+++ b/Bugsnag.NET/Request/Error.cs
@@ -8,11 +8,12 @@ namespace Bugsnag.NET.Request
 {
     public class Error : IError
     {
-        public Error(Exception ex)
+        public Error(Exception ex) : this(ex, x => x) { }
+        public Error(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             ErrorClass = ex.GetType().Name;
             Message = ex.Message;
-            Stacktrace = StackTraceLine.Build(ex);
+            Stacktrace = StackTraceLine.Build(ex, transformStacktraceLine);
         }
 
         public string ErrorClass { get; }

--- a/Bugsnag.NET/Request/Error.cs
+++ b/Bugsnag.NET/Request/Error.cs
@@ -9,7 +9,7 @@ namespace Bugsnag.NET.Request
     public class Error : IError
     {
         public Error(Exception ex) : this(ex, x => x) { }
-        public Error(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
+        public Error(Exception ex, Func<IMutableStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             ErrorClass = ex.GetType().Name;
             Message = ex.Message;

--- a/Bugsnag.NET/Request/Event.cs
+++ b/Bugsnag.NET/Request/Event.cs
@@ -11,7 +11,7 @@ namespace Bugsnag.NET.Request
     public class Event : IEvent
     {
         public Event(Exception ex) : this(ex, x => x) { }
-        public Event(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
+        public Event(Exception ex, Func<IMutableStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             Errors = _GetErrors(ex, transformStacktraceLine);
             GroupingHash = _GetGroupingHash(ex);
@@ -19,7 +19,7 @@ namespace Bugsnag.NET.Request
         }
 
         public Event(IEnumerable<Exception> unwrapped) : this(unwrapped, x => x) { }
-        public Event(IEnumerable<Exception> unwrapped, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
+        public Event(IEnumerable<Exception> unwrapped, Func<IMutableStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             Errors = _GetErrors(unwrapped, transformStacktraceLine);
             GroupingHash = _GetGroupingHash(unwrapped);
@@ -56,14 +56,14 @@ namespace Bugsnag.NET.Request
 
         public object MetaData { get; set; }
 
-        static IEnumerable<IError> _GetErrors(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
+        static IEnumerable<IError> _GetErrors(Exception ex, Func<IMutableStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             if (ex == null) { return Enumerable.Empty<IError>(); }
 
             return _GetErrors(ex.Unwrap(), transformStacktraceLine);
         }
 
-        static IEnumerable<IError> _GetErrors(IEnumerable<Exception> unwrapped, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
+        static IEnumerable<IError> _GetErrors(IEnumerable<Exception> unwrapped, Func<IMutableStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             return unwrapped.Select(ex => new Error(ex, transformStacktraceLine));
         }

--- a/Bugsnag.NET/Request/Event.cs
+++ b/Bugsnag.NET/Request/Event.cs
@@ -10,16 +10,18 @@ namespace Bugsnag.NET.Request
 {
     public class Event : IEvent
     {
-        public Event(Exception ex)
+        public Event(Exception ex) : this(ex, x => x) { }
+        public Event(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
-            Errors = _GetErrors(ex);
+            Errors = _GetErrors(ex, transformStacktraceLine);
             GroupingHash = _GetGroupingHash(ex);
             Context = _GetContext(ex);
         }
 
-        public Event(IEnumerable<Exception> unwrapped)
+        public Event(IEnumerable<Exception> unwrapped) : this(unwrapped, x => x) { }
+        public Event(IEnumerable<Exception> unwrapped, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
-            Errors = _GetErrors(unwrapped);
+            Errors = _GetErrors(unwrapped, transformStacktraceLine);
             GroupingHash = _GetGroupingHash(unwrapped);
             Context = _GetContext(unwrapped);
         }
@@ -54,16 +56,16 @@ namespace Bugsnag.NET.Request
 
         public object MetaData { get; set; }
 
-        static IEnumerable<IError> _GetErrors(Exception ex)
+        static IEnumerable<IError> _GetErrors(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
             if (ex == null) { return Enumerable.Empty<IError>(); }
 
-            return _GetErrors(ex.Unwrap());
+            return _GetErrors(ex.Unwrap(), transformStacktraceLine);
         }
 
-        static IEnumerable<IError> _GetErrors(IEnumerable<Exception> unwrapped)
+        static IEnumerable<IError> _GetErrors(IEnumerable<Exception> unwrapped, Func<IStackTraceLine, IStackTraceLine> transformStacktraceLine)
         {
-            return unwrapped.Select(ex => new Error(ex));
+            return unwrapped.Select(ex => new Error(ex, transformStacktraceLine));
         }
 
         static string _GetGroupingHash(Exception ex)
@@ -102,6 +104,7 @@ namespace Bugsnag.NET.Request
         static string _GetContext(IEnumerable<Exception> unwrapped) =>
             _exceptionInspector.GetContext(unwrapped.FirstOrDefault());
 
+        [Obsolete]
         public void AddContext(string memberName, string sourceFilePath, int sourceLineNumber)
         {
             Context = memberName;

--- a/Bugsnag.NET/Request/StackTraceLine.cs
+++ b/Bugsnag.NET/Request/StackTraceLine.cs
@@ -10,19 +10,24 @@ namespace Bugsnag.NET.Request
 {
     public class StackTraceLine : IStackTraceLine
     {
-        public static IEnumerable<IStackTraceLine> Build(Exception ex)
+        public static IEnumerable<IStackTraceLine> Build(Exception ex) => Build(ex, x => x);
+        public static IEnumerable<IStackTraceLine> Build(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStackTraceLine)
         {
             foreach (var line in ex.ToLines())
             {
-                yield return new StackTraceLine
-                {
-                    File = line.ParseFile(),
-                    LineNumber = line.ParseLineNumber(),
-                    Method = line.ParseMethodName()
-                };
+                yield return transformStackTraceLine(
+                    new StackTraceLine
+                    {
+                        File = line.ParseFile(),
+                        LineNumber = line.ParseLineNumber(),
+                        Method = line.ParseMethodName(),
+                        InProject = true,
+                    }
+                );
             }
         }
 
+        [Obsolete]
         internal static IEnumerable<IStackTraceLine> Build(string memberName, string sourceFilePath, int sourceLineNumber)
         {
             yield return new StackTraceLine

--- a/Bugsnag.NET/Request/StackTraceLine.cs
+++ b/Bugsnag.NET/Request/StackTraceLine.cs
@@ -8,10 +8,10 @@ using Bugsnag.Common;
 
 namespace Bugsnag.NET.Request
 {
-    public class StackTraceLine : IStackTraceLine
+    public class StackTraceLine : IMutableStackTraceLine
     {
         public static IEnumerable<IStackTraceLine> Build(Exception ex) => Build(ex, x => x);
-        public static IEnumerable<IStackTraceLine> Build(Exception ex, Func<IStackTraceLine, IStackTraceLine> transformStackTraceLine)
+        public static IEnumerable<IStackTraceLine> Build(Exception ex, Func<IMutableStackTraceLine, IStackTraceLine> transformStackTraceLine)
         {
             foreach (var line in ex.ToLines())
             {
@@ -38,14 +38,10 @@ namespace Bugsnag.NET.Request
             };
         }
 
-        public string File { get; private set; }
-
-        public int LineNumber { get; private set; }
-
-        public int? ColumnNumber { get; private set; }
-
-        public string Method { get; private set; }
-
-        public bool InProject { get; private set; }
+        public string File { get; set; }
+        public int LineNumber { get; set; }
+        public int? ColumnNumber { get; set; }
+        public string Method { get; set; }
+        public bool InProject { get; set; }
     }
 }

--- a/Bugsnag.NET/StackTraceLineHelper.cs
+++ b/Bugsnag.NET/StackTraceLineHelper.cs
@@ -1,0 +1,32 @@
+﻿using Bugsnag.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Bugsnag.NET
+{
+    public static class StackTraceLineHelper
+    {
+        const string _defaultFileValue = "[file]";
+
+        public static bool HasSuccessfullyParsedFile(this IStackTraceLine line) => line?.File != _defaultFileValue;
+
+        public static bool IsFromNamespaces(
+            this IStackTraceLine line,
+            params string[] prefixes) => prefixes.Any(str => (line?.Method?.StartsWith(str)).GetValueOrDefault());
+
+        public static string TryGetTrimmedFile(this IStackTraceLine line, Regex regex) => line.TryGetTrimmedFile(regex, str => str);
+        public static string TryGetTrimmedFile(this IStackTraceLine line, Regex regex, Func<string, string> additionalTransformOnSuccess)
+        {
+            var fileName = line?.File ?? _defaultFileValue; // NOTE: Not sure if a better thing here to coerce or just blow up
+            var match = regex.Match(fileName);
+
+            return match.Success
+                ? additionalTransformOnSuccess(match.Value)
+                : fileName;
+        }
+    }
+}

--- a/Bugsnag.PCL/Bugsnagger.cs
+++ b/Bugsnag.PCL/Bugsnagger.cs
@@ -18,6 +18,7 @@ namespace Bugsnag.PCL
         public IApp App { get; set; } = new App();
         public IDevice Device { get; set; } = new Device();
         public INotifier Notifier { get; set; } = new Notifier();
+        public Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; } = x => x;
 
         public Task<HttpResponseMessage> ErrorAsync(Exception ex, IUser user, object metadata)
         {

--- a/Bugsnag.PCL/Bugsnagger.cs
+++ b/Bugsnag.PCL/Bugsnagger.cs
@@ -18,7 +18,7 @@ namespace Bugsnag.PCL
         public IApp App { get; set; } = new App();
         public IDevice Device { get; set; } = new Device();
         public INotifier Notifier { get; set; } = new Notifier();
-        public Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; } = x => x;
+        public Func<IMutableStackTraceLine, IStackTraceLine> FinalizeStacktraceLine { get; set; } = x => x;
 
         public Task<HttpResponseMessage> ErrorAsync(Exception ex, IUser user, object metadata)
         {

--- a/lib/Bugsnag.Common/Interfaces/IBugsnagger.cs
+++ b/lib/Bugsnag.Common/Interfaces/IBugsnagger.cs
@@ -15,7 +15,7 @@ namespace Bugsnag.Common
         IApp App { get; set; }
         IDevice Device { get; set; }
 
-        Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; }
+        Func<IMutableStackTraceLine, IStackTraceLine> FinalizeStacktraceLine { get; set; }
 
         void Error(Exception ex, IUser user, object metadata);
         void Warning(Exception ex, IUser user, object metadata);

--- a/lib/Bugsnag.Common/Interfaces/IBugsnagger.cs
+++ b/lib/Bugsnag.Common/Interfaces/IBugsnagger.cs
@@ -15,6 +15,8 @@ namespace Bugsnag.Common
         IApp App { get; set; }
         IDevice Device { get; set; }
 
+        Func<IStackTraceLine, IStackTraceLine> TransformStacktraceLine { get; set; }
+
         void Error(Exception ex, IUser user, object metadata);
         void Warning(Exception ex, IUser user, object metadata);
         void Info(Exception ex, IUser user, object metadata);

--- a/lib/Bugsnag.Common/Interfaces/IStackTraceLine.cs
+++ b/lib/Bugsnag.Common/Interfaces/IStackTraceLine.cs
@@ -26,4 +26,15 @@ namespace Bugsnag.Common
 
         // TODO: Code
     }
+
+    public interface IMutableStackTraceLine : IStackTraceLine
+    {
+        new string File { get; set; }
+        new int LineNumber { get; set; }
+        new int? ColumnNumber { get; set; }
+        new string Method { get; set; }
+        new bool InProject { get; set; }
+
+        // TODO: Code
+    }
 }


### PR DESCRIPTION
Plumb it all the way through so that the consuming app can have flexible control over how stack trace info is shipped off to Bugsnag, but still just use the default if that's enough.