### PR TITLE
Define "[file]" in one place only

### DIFF
--- a/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
+++ b/Bugsnag.NET.Tests/StacktracelineParsingTests.cs
@@ -28,7 +28,7 @@ namespace Bugsnag.NET.Tests
         readonly string _asyncAwaitPreviousLocationLine = @"--- End of stack trace from previous location where exception was thrown ---";
 
         readonly string _parseFailedMethodName = "[method]";
-        readonly string _parseFailedFile = "[file]";
+        readonly string _parseFailedFile = CommonExtensions.FileParseFailureDefaultValue;
         readonly int _parseFailedLineNumber = -1;
 
         [Test]

--- a/Bugsnag.NET/StackTraceLineHelper.cs
+++ b/Bugsnag.NET/StackTraceLineHelper.cs
@@ -1,4 +1,5 @@
 ﻿using Bugsnag.Common;
+using Bugsnag.Common.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,9 +11,9 @@ namespace Bugsnag.NET
 {
     public static class StackTraceLineHelper
     {
-        const string _defaultFileValue = "[file]";
+        static string _DefaultFileValue => CommonExtensions.FileParseFailureDefaultValue;
 
-        public static bool HasSuccessfullyParsedFile(this IStackTraceLine line) => line?.File != _defaultFileValue;
+        public static bool HasSuccessfullyParsedFile(this IStackTraceLine line) => line?.File != _DefaultFileValue;
 
         public static bool IsFromNamespaces(
             this IStackTraceLine line,
@@ -21,7 +22,7 @@ namespace Bugsnag.NET
         public static string TryGetTrimmedFile(this IStackTraceLine line, Regex regex) => line.TryGetTrimmedFile(regex, str => str);
         public static string TryGetTrimmedFile(this IStackTraceLine line, Regex regex, Func<string, string> additionalTransformOnSuccess)
         {
-            var fileName = line?.File ?? _defaultFileValue; // NOTE: Not sure if a better thing here to coerce or just blow up
+            var fileName = line?.File ?? _DefaultFileValue; // NOTE: Not sure if a better thing here to coerce or just blow up
             var match = regex.Match(fileName);
 
             return match.Success

--- a/lib/Bugsnag.Common/Extensions/CommonExtensions.cs
+++ b/lib/Bugsnag.Common/Extensions/CommonExtensions.cs
@@ -36,10 +36,12 @@ namespace Bugsnag.Common.Extensions
             );
         }
 
+        public static string FileParseFailureDefaultValue = "[file]";
+
         public static string ParseFile(this string line)
         {
             var match = Regex.Match(line, "in (.+):line");
-            if (match.Groups.Count < 2) { return "[file]"; }
+            if (match.Groups.Count < 2) { return FileParseFailureDefaultValue; }
 
             return match.Groups[1].Value;
         }


### PR DESCRIPTION
Will prevent the "Oops, I guess I missed a reference" case from happening.