### PR TITLE
fix: Remove .Wait() call

### DIFF
--- a/lib/Bugsnag.Common/BugsnagClient.cs
+++ b/lib/Bugsnag.Common/BugsnagClient.cs
@@ -16,8 +16,17 @@ namespace Bugsnag.Common
         static HttpClient _HttpClient { get; } = new HttpClient();
 
         public void Send(INotice notice) => Send(notice, true);
+        public void Send(INotice notice, bool useSSL) => Send(notice, useSSL, _ => { });
+        public void Send(INotice notice, Action<Exception> onException) => Send(notice, true, onException);
 
-        public void Send(INotice notice, bool useSSL) => SendAsync(notice, useSSL).Wait();
+        public void Send(INotice notice, bool useSSL, Action<Exception> onException) => Task.Run(async () =>
+        {
+            try
+            {
+                await SendAsync(notice, useSSL);
+            }
+            catch (Exception ex) { onException(ex); }
+        });
 
         public Task<HttpResponseMessage> SendAsync(INotice notice) => SendAsync(notice, true);
 

--- a/lib/Bugsnag.Common/Interfaces/IClient.cs
+++ b/lib/Bugsnag.Common/Interfaces/IClient.cs
@@ -10,7 +10,9 @@ namespace Bugsnag.Common
     public interface IClient
     {
         void Send(INotice notice);
+        void Send(INotice notice, Action<Exception> onException);
         void Send(INotice notice, bool useSSL);
+        void Send(INotice notice, bool useSSL, Action<Exception> onException);
         Task<HttpResponseMessage> SendAsync(INotice notice);
         Task<HttpResponseMessage> SendAsync(INotice notice, bool useSSL);
     }


### PR DESCRIPTION
This is bad news and shouldn't be here.

The new approach also doesn't feel amazing, but is at least a little better.